### PR TITLE
fix bugs in languageselector and accept view

### DIFF
--- a/example/themes/business/src/components/AcceptOrRejectOrder/index.tsx
+++ b/example/themes/business/src/components/AcceptOrRejectOrder/index.tsx
@@ -5,7 +5,7 @@ import {
   Platform,
   View,
   KeyboardAvoidingView,
-  SafeAreaView,
+  TextInput
 } from 'react-native';
 import { useTheme } from 'styled-components/native';
 import { useLanguage } from 'ordering-components/native';
@@ -13,6 +13,7 @@ import { Content, Timer, TimeField, Header, Action, Comments } from './styles';
 import { FloatingButton } from '../FloatingButton';
 import { OText, OButton, OTextarea, OIconButton } from '../shared';
 import { AcceptOrRejectOrderParams } from '../../types';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 export const AcceptOrRejectOrder = (props: AcceptOrRejectOrderParams) => {
   const {
@@ -33,7 +34,7 @@ export const AcceptOrRejectOrder = (props: AcceptOrRejectOrderParams) => {
   const theme = useTheme();
   const scrollViewRef = useRef<any>(null);
   const viewRef = useRef<any>(null);
-  const timerRef = useRef<any>();
+  const timerRef = useRef() as React.MutableRefObject<TextInput>;
   const textTareaRef = useRef<any>();
   const [hour, setHour] = useState('00');
   const [min, setMin] = useState('00');
@@ -42,6 +43,7 @@ export const AcceptOrRejectOrder = (props: AcceptOrRejectOrderParams) => {
   const [isKeyboardShow, setIsKeyboardShow] = useState(false);
   const phoneNumber = customerCellphone;
   let codeNumberPhone, numberPhone, numberToShow;
+  const { top, bottom} = useSafeAreaInsets()
 
   const handleFocus = () => {
     viewRef?.current?.measure((x: any, y: any) => {
@@ -104,6 +106,16 @@ export const AcceptOrRejectOrder = (props: AcceptOrRejectOrderParams) => {
     setTime(`${hours}${mins}`);
   };
 
+  useEffect(() => {
+    if (actions && action === 'accept') {
+      openTimerIOnput();
+    }
+
+    if (actions && action === 'reject') {
+      openTextTareaOInput();
+    }
+  }, []);
+
   const handleFixTime = () => {
     if (min >= '60') {
       setMin('59');
@@ -117,11 +129,11 @@ export const AcceptOrRejectOrder = (props: AcceptOrRejectOrderParams) => {
 
   const openTimerIOnput = () => {
     const isFocus = timerRef.current.isFocused();
-    if (isFocus && timerRef?.current) {
+    if (isFocus) {
       timerRef.current.blur();
     }
 
-    if (!isFocus && timerRef?.current) {
+    if (!isFocus) {
       if (time.length > 1) timerRef.current.clear();
       timerRef.current.focus();
       handleFocusTimer();
@@ -181,10 +193,11 @@ export const AcceptOrRejectOrder = (props: AcceptOrRejectOrderParams) => {
   };
 
   return (
-    <SafeAreaView style={{ flex: 1 }}>
       <KeyboardAvoidingView
+      enabled
         behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-        style={{ flex: 1, paddingHorizontal: 30, paddingTop: 30 }}>
+        style={{ flex: 1, paddingHorizontal: 30, paddingTop: 30, marginTop: top, marginBottom: bottom,justifyContent: 'space-between' }}>
+          <View>
         <OIconButton
           icon={theme.images.general.arrow_left}
           borderColor={theme.colors.clear}
@@ -209,6 +222,7 @@ export const AcceptOrRejectOrder = (props: AcceptOrRejectOrderParams) => {
             ? `${t(titleAccept?.key, titleAccept?.text)}:`
             : t(titleReject?.key, titleReject?.text)}
         </OText>
+        </View>
         <Content showsVerticalScrollIndicator={false} ref={scrollViewRef}>
           <Header>
             {action === 'reject' && (
@@ -316,7 +330,7 @@ export const AcceptOrRejectOrder = (props: AcceptOrRejectOrderParams) => {
               </Timer>
             </View>
           )}
-
+            
           <TimeField
             ref={timerRef}
             keyboardType="numeric"
@@ -365,6 +379,5 @@ export const AcceptOrRejectOrder = (props: AcceptOrRejectOrderParams) => {
           />
         </Action>
       </KeyboardAvoidingView>
-    </SafeAreaView>
   );
 };

--- a/example/themes/business/src/components/AcceptOrRejectOrder/styles.tsx
+++ b/example/themes/business/src/components/AcceptOrRejectOrder/styles.tsx
@@ -1,9 +1,8 @@
 import styled from 'styled-components/native';
 
 export const Content = styled.ScrollView`
-  margin-bottom: 60px;
   background-color: ${(props: any) => props.theme.colors.white};
-  flex: 1;
+  margin-bottom: 30px;
 `;
 
 export const Timer = styled.TouchableOpacity`
@@ -33,6 +32,5 @@ export const Header = styled.View``;
 export const Action = styled.View``;
 
 export const Comments = styled.View`
-  margin-bottom: 40px;
   margin-top: 20px;
 `;

--- a/example/themes/business/src/components/LanguageSelector/index.tsx
+++ b/example/themes/business/src/components/LanguageSelector/index.tsx
@@ -60,8 +60,6 @@ const LanguageSelectorUI = (props: LanguageSelectorParams) => {
           withCountryNameButton
           countryCodes={countryCodes}
           //@ts-ignore
-          closeButtonImageStyle={{ width: 15, height: 15 }}
-          closeButtonImage={theme.images.general.close}
           renderFlagButton={() => (
             <TouchableOpacity onPress={() => setCountryModalVisible(true)}>
               <LanguageItem justifyContent="space-between">
@@ -79,7 +77,7 @@ const LanguageSelectorUI = (props: LanguageSelectorParams) => {
 
                 <OIcon
                   src={theme?.images?.general?.chevronDown}
-                  color={theme.colors.backArrow}
+
                   width={20}
                   height={20}
                 />


### PR DESCRIPTION
Fixed the next:
1) Before:  bug in close image in language selector
<img width="399" alt="Screen Shot 2021-10-08 at 9 04 44 AM" src="https://user-images.githubusercontent.com/70044008/136576047-5ea07761-5dda-40b0-9bc0-071a626c8550.png">

after

<img width="417" alt="Screen Shot 2021-10-08 at 9 04 57 AM" src="https://user-images.githubusercontent.com/70044008/136576059-1a1cb5c7-661b-499b-b4ee-80db86165519.png">

2) Before: bug when keyboard is opening in ios, had more bottom padding
<img width="452" alt="Screen Shot 2021-10-08 at 10 39 36 AM" src="https://user-images.githubusercontent.com/70044008/136576280-9fdbb943-14a4-44ad-a071-7f9a324269fb.png">

After: 
<img width="386" alt="Screen Shot 2021-10-08 at 10 40 42 AM" src="https://user-images.githubusercontent.com/70044008/136576430-5c9a2deb-7293-4656-9f1c-570e7d1edffb.png">



